### PR TITLE
move to headers hash for idempotent calls

### DIFF
--- a/lib/stripe_mock/request_handlers/charges.rb
+++ b/lib/stripe_mock/request_handlers/charges.rb
@@ -13,9 +13,12 @@ module StripeMock
       end
 
       def new_charge(route, method_url, params, headers)
-        if params[:idempotency_key] && charges.any?
-          original_charge = charges.values.find { |c| c[:idempotency_key] == params[:idempotency_key]}
-          return charges[original_charge[:id]] if original_charge
+        if headers && headers[:idempotency_key]
+          params[:idempotency_key] = headers[:idempotency_key]
+          if charges.any?
+            original_charge = charges.values.find { |c| c[:idempotency_key] == headers[:idempotency_key]}
+            return charges[original_charge[:id]] if original_charge
+          end
         end
 
         id = new_id('ch')

--- a/lib/stripe_mock/request_handlers/refunds.rb
+++ b/lib/stripe_mock/request_handlers/refunds.rb
@@ -10,9 +10,12 @@ module StripeMock
       end
 
       def new_refund(route, method_url, params, headers)
-        if params[:idempotency_key] && refunds.any?
-          original_refund = refunds.values.find { |c| c[:idempotency_key] == params[:idempotency_key]}
-          return refunds[original_refund[:id]] if original_refund
+        if headers && headers[:idempotency_key]
+          params[:idempotency_key] = headers[:idempotency_key]
+          if refunds.any?
+            original_refund = refunds.values.find { |c| c[:idempotency_key] == headers[:idempotency_key]}
+            return refunds[original_refund[:id]] if original_refund
+          end
         end
 
         charge = assert_existence :charge, params[:charge], charges[params[:charge]]

--- a/spec/shared_stripe_examples/refund_examples.rb
+++ b/spec/shared_stripe_examples/refund_examples.rb
@@ -337,26 +337,32 @@ shared_examples 'Refund API' do
           capture: true
         )
       end
-      let(:idempotent_refund_params) {{
-        charge: charge.id,
+      let(:refund_params) {{
+        charge: charge.id
+      }}
+
+      let(:refund_headers) {{
         idempotency_key: 'onceisenough'
       }}
 
       it "returns the original refund if the same idempotency_key is passed in" do
-        refund1 = Stripe::Refund.create(idempotent_refund_params)
-        refund2 = Stripe::Refund.create(idempotent_refund_params)
+        refund1 = Stripe::Refund.create(refund_params, refund_headers)
+        refund2 = Stripe::Refund.create(refund_params, refund_headers)
 
         expect(refund1).to eq(refund2)
       end
 
-      it "returns different charges if different idempotency_keys are used for each charge" do
-        idempotent_refund_params2 = idempotent_refund_params.clone
-        idempotent_refund_params2[:idempotency_key] = 'thisoneisdifferent'
+      context 'different key' do
+        let(:different_refund_headers) {{
+          idempotency_key: 'thisoneisdifferent'
+        }}
 
-        refund1 = Stripe::Refund.create(idempotent_refund_params)
-        refund2 = Stripe::Refund.create(idempotent_refund_params2)
+        it "returns different charges if different idempotency_keys are used for each charge" do
+          refund1 = Stripe::Refund.create(refund_params, refund_headers)
+          refund2 = Stripe::Refund.create(refund_params, different_refund_headers)
 
-        expect(refund1).not_to eq(refund2)
+          expect(refund1).not_to eq(refund2)
+        end
       end
     end
   end


### PR DESCRIPTION
Stripe API expects idempotency key transferred via the headers and not the params hash.